### PR TITLE
Add IP Whitelisting support to TLS/TCP routers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/containous/multibuf v0.0.0-20190809014333-8b6c9a7e6bba h1:PhR03pep+5e
 github.com/containous/multibuf v0.0.0-20190809014333-8b6c9a7e6bba/go.mod h1:zkWcASFUJEst6QwCrxLdkuw1gvaKqmflEipm+iecV5M=
 github.com/containous/mux v0.0.0-20181024131434-c33f32e26898 h1:1srn9voikJGofblBhWy3WuZWqo14Ou7NaswNG/I2yWc=
 github.com/containous/mux v0.0.0-20181024131434-c33f32e26898/go.mod h1:z8WW7n06n8/1xF9Jl9WmuDeZuHAhfL+bwarNjsciwwg=
+github.com/containous/traefik v1.7.24 h1:iFkoJBpQUQh1URdblBjbh32Wav8Ctl/WjLtAtvBzHis=
 github.com/coreos/bbolt v1.3.3 h1:n6AiVyVRKQFNb6mJlwESEvvLoDyiTzXX7ORAUlkeBdY=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=

--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -51,7 +51,7 @@ type TCPRouter struct {
 	Service     string              `json:"service,omitempty" toml:"service,omitempty" yaml:"service,omitempty"`
 	Rule        string              `json:"rule,omitempty" toml:"rule,omitempty" yaml:"rule,omitempty"`
 	TLS         *RouterTCPTLSConfig `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty"`
-	IPWhitelist []string            `json:"ipWhitelist,omitempty" toml:"ipWhitelist,omitempty" yaml:"ipWhitelist,omitempty" label:"allowEmpty" file:"allowEmpty"`
+	IPWhitelist []string            `json:"ipWhitelist,omitempty" toml:"ipWhitelist,omitempty" yaml:"ipWhitelist,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -51,6 +51,7 @@ type TCPRouter struct {
 	Service     string              `json:"service,omitempty" toml:"service,omitempty" yaml:"service,omitempty"`
 	Rule        string              `json:"rule,omitempty" toml:"rule,omitempty" yaml:"rule,omitempty"`
 	TLS         *RouterTCPTLSConfig `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty"`
+	IPWhitelist []string            `json:"ipWhitelist,omitempty" toml:"ipWhitelist,omitempty" yaml:"ipWhitelist,omitempty" label:"allowEmpty" file:"allowEmpty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/ip/checker.go
+++ b/pkg/ip/checker.go
@@ -9,8 +9,8 @@ import (
 
 // Checker allows to check that addresses are in a trusted IPs.
 type Checker struct {
-	authorizedIPs    []*net.IP
-	authorizedIPsNet []*net.IPNet
+	AuthorizedIPs    []*net.IP
+	AuthorizedIPsNet []*net.IPNet
 }
 
 // NewChecker builds a new Checker given a list of CIDR-Strings to trusted IPs.
@@ -23,13 +23,13 @@ func NewChecker(trustedIPs []string) (*Checker, error) {
 
 	for _, ipMask := range trustedIPs {
 		if ipAddr := net.ParseIP(ipMask); ipAddr != nil {
-			checker.authorizedIPs = append(checker.authorizedIPs, &ipAddr)
+			checker.AuthorizedIPs = append(checker.AuthorizedIPs, &ipAddr)
 		} else {
 			_, ipAddr, err := net.ParseCIDR(ipMask)
 			if err != nil {
 				return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipAddr, err)
 			}
-			checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
+			checker.AuthorizedIPsNet = append(checker.AuthorizedIPsNet, ipAddr)
 		}
 	}
 
@@ -74,13 +74,13 @@ func (ip *Checker) Contains(addr string) (bool, error) {
 
 // ContainsIP checks if provided address is in the trusted IPs.
 func (ip *Checker) ContainsIP(addr net.IP) bool {
-	for _, authorizedIP := range ip.authorizedIPs {
+	for _, authorizedIP := range ip.AuthorizedIPs {
 		if authorizedIP.Equal(addr) {
 			return true
 		}
 	}
 
-	for _, authorizedNet := range ip.authorizedIPsNet {
+	for _, authorizedNet := range ip.AuthorizedIPsNet {
 		if authorizedNet.Contains(addr) {
 			return true
 		}

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -93,7 +93,7 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 				EntryPoints: ingressRouteTCP.Spec.EntryPoints,
 				Rule:        route.Match,
 				Service:     serviceName,
-				IPWhitelist: ingressRouteTCP.Spec.IPWhitelist,
+				IPWhitelist: route.IPWhitelist,
 			}
 
 			if ingressRouteTCP.Spec.TLS != nil {

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -93,6 +93,7 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 				EntryPoints: ingressRouteTCP.Spec.EntryPoints,
 				Rule:        route.Match,
 				Service:     serviceName,
+				IPWhitelist: ingressRouteTCP.Spec.IPWhitelist,
 			}
 
 			if ingressRouteTCP.Spec.TLS != nil {

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
@@ -10,13 +10,13 @@ type IngressRouteTCPSpec struct {
 	Routes      []RouteTCP `json:"routes"`
 	EntryPoints []string   `json:"entryPoints"`
 	TLS         *TLSTCP    `json:"tls,omitempty"`
-	IPWhitelist []string   `json:"ipWhitelist"`
 }
 
 // RouteTCP contains the set of routes.
 type RouteTCP struct {
-	Match    string       `json:"match"`
-	Services []ServiceTCP `json:"services,omitempty"`
+	Match       string       `json:"match"`
+	Services    []ServiceTCP `json:"services,omitempty"`
+	IPWhitelist []string     `json:"ipWhitelist"`
 }
 
 // TLSTCP contains the TLS certificates configuration of the routes.

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
@@ -10,6 +10,7 @@ type IngressRouteTCPSpec struct {
 	Routes      []RouteTCP `json:"routes"`
 	EntryPoints []string   `json:"entryPoints"`
 	TLS         *TLSTCP    `json:"tls,omitempty"`
+	IPWhitelist []string   `json:"ipWhitelist"`
 }
 
 // RouteTCP contains the set of routes.

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -199,7 +199,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 		}
 
 		// Create a new IP Checker for whitelisted IPs
-		var ipChecker *ip.Checker
+		ipChecker := &ip.Checker{}
 		if len(routerConfig.IPWhitelist) > 0 {
 			ipChecker, err = ip.NewChecker(routerConfig.IPWhitelist)
 			if err != nil {
@@ -254,11 +254,6 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 				logger.Warn("TCP Router ignored, cannot specify a Host rule without TLS")
 			}
 		}
-
-		/*Need to look up IP Addresses and set them here*/
-		/*need to use the functions NewChecker and IsAuthorized in pkg/ip/checker.go*/
-		/* Need to ultimately do the pass/fail in the pkg/tcp/router.go line 67 */
-		/* But how do I get the list of IPs into that file? */
 	}
 
 	return router, nil

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containous/traefik/v2/pkg/config/runtime"
+	"github.com/containous/traefik/v2/pkg/ip"
 	"github.com/containous/traefik/v2/pkg/log"
 	"github.com/containous/traefik/v2/pkg/server/provider"
 	"github.com/containous/traefik/v2/pkg/tcp"
@@ -26,7 +27,7 @@ func NewManager(conf *runtime.Configuration) *Manager {
 }
 
 // BuildTCP Creates a tcp.Handler for a service configuration.
-func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Handler, error) {
+func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string, ipChecker *ip.Checker) (tcp.Handler, error) {
 	serviceQualifiedName := provider.GetQualifiedName(rootCtx, serviceName)
 	ctx := provider.AddInContext(rootCtx, serviceQualifiedName)
 	ctx = log.With(ctx, log.Str(log.ServiceName, serviceName))
@@ -72,7 +73,7 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 	case conf.Weighted != nil:
 		loadBalancer := tcp.NewWRRLoadBalancer()
 		for _, service := range conf.Weighted.Services {
-			handler, err := m.BuildTCP(rootCtx, service.Name)
+			handler, err := m.BuildTCP(rootCtx, service.Name, ipChecker)
 			if err != nil {
 				logger.Errorf("In service %q: %v", serviceQualifiedName, err)
 				return nil, err

--- a/pkg/tcp/router.go
+++ b/pkg/tcp/router.go
@@ -69,19 +69,25 @@ func (r *Router) ServeTCP(conn WriteCloser) {
 		}
 		return
 	}
-	serverName = strings.ToLower(serverName)
-	remoteAddr := conn.RemoteAddr().String()
-	whitelistChecker := r.routingTable[serverName].checker
-	//Check if ip is allowed
-	err = whitelistChecker.IsAuthorized(remoteAddr)
-	if err != nil {
-		log.WithoutContext().Infof("Address %v is not in the whitelist", remoteAddr)
-		conn.Close()
-	}
 
+	serverName = strings.ToLower(serverName)
 	// FIXME Optimize and test the routing table before helloServerName
 	if r.routingTable != nil && serverName != "" {
 		if target, ok := r.routingTable[serverName]; ok {
+
+			remoteAddr := conn.RemoteAddr().String()
+			whitelistChecker := r.routingTable[serverName].checker
+			// If there are no whitelisted IPs, everything is allowed so don't check
+			if len(whitelistChecker.AuthorizedIPs) != 0 || len(whitelistChecker.AuthorizedIPsNet) != 0 {
+				//Check if ip is allowed
+				err = whitelistChecker.IsAuthorized(remoteAddr)
+				if err != nil {
+					log.WithoutContext().Debugf("Address %v is not in the whitelist", remoteAddr)
+					conn.Close()
+					return
+				}
+			}
+
 			target.handler.ServeTCP(r.GetConn(conn, peeked))
 			return
 		}


### PR DESCRIPTION
This is a hack to allow IP Whitelisting on TLS endpoints, specifically ones that have Passthrough enabled.

The correct solution would be official Middleware support for TCP/TLS routes from Traefik, but I can't wait on that. So I came up with this. I only use this from the Kubernetes CRD so I don't even know how to use it outside of Kubernetes.

Examples IngressRouteTCP:

```
apiVersion: traefik.containo.us/v1alpha1
kind: IngressRouteTCP
metadata:
  name: exampleTcpRoute
  namespace: myNamespace
spec:
  entryPoints:
    - web
  tls:
    passthrough: true
  routes:
  - match: HostSNI(`myapp.com`)
    kind: Rule
    ipWhitelist:
      - 192.168.65.3
      - 8.8.8.0/24
    services:
    - name: myService
      scheme: tcp
      port: 8080
```

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
